### PR TITLE
Reduce default client cache time of random images

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -13,10 +13,10 @@ const server = http.createServer(app);
 
 // Config
 const port = process.env.PORT || 3000;
-const maxAge = process.env.RANDOM_MAX_AGE || 60 * 60 * 24;
+const randomMaxAge = process.env.RANDOM_MAX_AGE || 5;
 const publicPath = process.env.PUBLIC_PATH || 'public';
 
-const imageController = new ImageController({ maxAge });
+const imageController = new ImageController({ randomMaxAge });
 
 process.on('uncaughtException', function(err) {
 	console.log('Caught exception: ' + err);

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -13,7 +13,7 @@ const server = http.createServer(app);
 
 // Config
 const port = process.env.PORT || 3000;
-const randomMaxAge = process.env.RANDOM_MAX_AGE || 5;
+const randomMaxAge = process.env.RANDOM_MAX_AGE || 600;
 const publicPath = process.env.PUBLIC_PATH || 'public';
 
 const imageController = new ImageController({ randomMaxAge });


### PR DESCRIPTION
The random Arnold pictures (and probably also the other, lesser pictures) are cached for too long.  One random Arnold picture per day is not enough.

This change would reduce the default client cache duration on random images from 24 hours to 5 seconds, without changing the cache duration for the endpoint that specifies the image id.